### PR TITLE
Add .gitignore, add clean target to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+satania
+*.o

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ $(BIN): $(OBJ)
 
 run: $(BIN)
 	./$(BIN)
+
+clean:
+	rm satania *.o

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 dependencies: X11, cairo (plus development libraries)  
 compile: make  
 run: make run  
+clean: make clean
 
 Config:  
 currently config file location is ./satania.cfg  


### PR DESCRIPTION
This PR adds a basic .gitignore for object files and the main binary.

This PR also adds a `make clean` target to the Makefile, which removes object files and the main binary.